### PR TITLE
feat: agoric contract to call any contract on ethereum

### DIFF
--- a/contract/axelar-gmp.contract.js
+++ b/contract/axelar-gmp.contract.js
@@ -21,7 +21,7 @@ export const SingleNatAmountRecord = M.and(
   M.recordOf(M.string(), AnyNatAmountShape, {
     numPropertiesLimit: 1,
   }),
-  M.not(harden({}))
+  M.not(harden({})),
 );
 harden(SingleNatAmountRecord);
 
@@ -42,7 +42,7 @@ export const contract = async (
   zcf,
   privateArgs,
   zone,
-  { chainHub, orchestrateAll, vowTools, zoeTools }
+  { chainHub, orchestrateAll, vowTools, zoeTools, zcfTools, baggage },
 ) => {
   console.log('Inside Contract');
 
@@ -51,12 +51,13 @@ export const contract = async (
     chainHub,
     zcf.getTerms().brands,
     privateArgs.chainInfo,
-    privateArgs.assetInfo
+    privateArgs.assetInfo,
   );
 
   const makeEvmAccountKit = prepareEvmAccountKit(zone.subZone('evmTap'), {
     vowTools,
     zcf,
+    zoeTools,
   });
 
   const creatorFacet = prepareChainHubAdmin(zone, chainHub);
@@ -91,6 +92,10 @@ export const contract = async (
     makeEvmAccountKit,
     log,
     chainHub,
+    zoeTools,
+    baggage,
+    zcfTools,
+    zone,
   });
 
   const publicFacet = zone.exo(
@@ -105,7 +110,7 @@ export const contract = async (
           sendGmp,
           'send',
           undefined,
-          M.splitRecord({ give: SingleNatAmountRecord })
+          M.splitRecord({ give: SingleNatAmountRecord }),
         );
       },
       createAndMonitorLCA() {
@@ -122,5 +127,5 @@ export const contract = async (
 };
 harden(contract);
 
-export const start = withOrchestration(contract);
+export const start = withOrchestration(contract, { publishAccountInfo: true });
 harden(start);

--- a/contract/info.js
+++ b/contract/info.js
@@ -1,3 +1,16 @@
+
+const osmosisData = {
+  channelId: 'channel-10170',
+  clientId: '07-tendermint-4441',
+  connectionId: 'connection-3881',
+}
+
+const agoricData = {
+  channelId: 'channel-0',
+  clientId: '07-tendermint-0',
+  connectionId: 'connection-0',
+}
+
 export const chainInfo = JSON.stringify({
   agoric: {
     chainId: 'agoriclocal',
@@ -8,17 +21,35 @@ export const chainInfo = JSON.stringify({
     ],
     connections: {
       'osmo-test-5': {
+        id: agoricData.connectionId,
+        client_id: agoricData.clientId,
+        counterparty: {
+          client_id: osmosisData.clientId,
+          connection_id: osmosisData.connectionId,
+        },
+        state: 3,
+        transferChannel: {
+          channelId: agoricData.channelId,
+          portId: 'transfer',
+          counterPartyChannelId: osmosisData.channelId,
+          counterPartyPortId: 'transfer',
+          ordering: 0,
+          state: 3,
+          version: 'ics20-1',
+        },
+      },
+      axelar: {
         id: 'connection-0',
         client_id: '07-tendermint-0',
         counterparty: {
-          client_id: '07-tendermint-4486',
-          connection_id: 'connection-3921',
+          client_id: '07-tendermint-0',
+          connection_id: 'connection-0',
         },
         state: 3,
         transferChannel: {
           channelId: 'channel-0',
           portId: 'transfer',
-          counterPartyChannelId: 'channel-10226',
+          counterPartyChannelId: 'channel-0',
           counterPartyPortId: 'transfer',
           ordering: 0,
           state: 3,
@@ -37,17 +68,17 @@ export const chainInfo = JSON.stringify({
     ],
     connections: {
       agoriclocal: {
-        id: 'connection-3921',
-        client_id: '07-tendermint-4486',
+        id: osmosisData.connectionId,
+        client_id: osmosisData.clientId,
         counterparty: {
-          client_id: '07-tendermint-0',
-          connection_id: 'connection-0',
+          client_id: agoricData.clientId,
+          connection_id: agoricData.connectionId,
         },
         state: 3,
         transferChannel: {
-          channelId: 'channel-10226',
+          channelId: osmosisData.channelId,
           portId: 'transfer',
-          counterPartyChannelId: 'channel-0',
+          counterPartyChannelId: agoricData.channelId,
           counterPartyPortId: 'transfer',
           ordering: 0,
           state: 3,
@@ -56,6 +87,35 @@ export const chainInfo = JSON.stringify({
       },
     },
   },
+
+  axelar: {
+    chainId: 'axelar',
+    stakingTokens: [
+      {
+        denom: 'uaxl',
+      },
+    ],
+    connections: {
+      agoriclocal: {
+        id: 'connection-0',
+        client_id: '07-tendermint-0',
+        counterparty: {
+          client_id: '07-tendermint-0',
+          connection_id: 'connection-0',
+        },
+        state: 3,
+        transferChannel: {
+          channelId: 'channel-0',
+          portId: 'transfer',
+          counterPartyChannelId: 'channel-0',
+          counterPartyPortId: 'transfer',
+          ordering: 0,
+          state: 3,
+          version: 'ics20-1',
+        },
+      },
+    }
+  }
 });
 
 /**
@@ -72,6 +132,14 @@ export const assetInfo = JSON.stringify([
     'uist',
     {
       baseDenom: 'uist',
+      baseName: 'agoric',
+      chainName: 'agoric',
+    },
+  ],
+  [
+    'ubld',
+    {
+      baseDenom: 'ubld',
       baseName: 'agoric',
       chainName: 'agoric',
     },
@@ -100,6 +168,15 @@ export const assetInfo = JSON.stringify([
       baseName: 'osmosis',
       chainName: 'agoric',
       brandKey: 'WAVAX',
+    },
+  ],
+  [
+    'ibc/2CC0B1B7A981ACC74854717F221008484603BB8360E81B262411B0D830EDE9B0',
+    {
+      baseDenom: 'uaxl',
+      baseName: 'axelar',
+      chainName: 'agoric',
+      brandKey: 'AXL',
     },
   ],
 ]);

--- a/contract/package.json
+++ b/contract/package.json
@@ -6,21 +6,24 @@
   "devDependencies": {
     "@agoric/async-flow": "^0.2.0-u18a.0",
     "@agoric/deploy-script-support": "^0.10.4-u19.1",
+    "@endo/ses-ava": "^1.2.9",
     "agoric": "^0.22.0-u17.1"
   },
   "dependencies": {
     "@agoric/internal": "^0.4.0-u19.1",
     "@agoric/orchestration": "^0.2.0-u19.1",
+    "@agoric/vat-data": "^0.5.3-u19.2",
     "@agoric/vats": "^0.16.0-u17.1",
+    "@agoric/vow": "^0.2.0-u17.1",
     "@agoric/zoe": "^0.26.3-u17.1",
+    "@agoric/zone": "^0.3.0-u17.1",
     "@endo/base64": "^1.0.9",
     "@endo/errors": "^1.2.9",
     "@endo/far": "^1.1.4",
     "@endo/patterns": "^1.4.8",
-    "@agoric/vow": "^0.2.0-u17.1",
-    "@agoric/zone": "^0.3.0-u17.1",
     "@ethersproject/bytes": "^5.8.0",
-    "@findeth/abi": "^0.7.1"
+    "@findeth/abi": "^0.7.1",
+    "js-sha3": "^0.9.3"
   },
   "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/contract/proposal/start-axelar-gmp.js
+++ b/contract/proposal/start-axelar-gmp.js
@@ -83,17 +83,17 @@ export const startAxelarGmp = async (
     })
   );
 
-  // /** @param {() => Promise<Issuer>} p */
-  // const safeFulfill = async p =>
-  //   E.when(
-  //     p(),
-  //     i => i,
-  //     () => undefined,
-  //   );
+  /** @param {() => Promise<Issuer>} p */
+  const safeFulfill = async (p) =>
+    E.when(
+      p(),
+      (i) => i,
+      () => undefined
+    );
 
-  // const ausdcIssuer = await safeFulfill(() =>
-  //   E(agoricNames).lookup('issuer', 'AUSDC'),
-  // );
+  const axlIssuer = await safeFulfill(() =>
+    E(agoricNames).lookup('issuer', 'AXL')
+  );
 
   // const wavaxIssuer = await safeFulfill(() =>
   //   E(agoricNames).lookup('issuer', 'WAVAX'),
@@ -102,7 +102,7 @@ export const startAxelarGmp = async (
   const issuerKeywordRecord = harden({
     BLD: await BLD,
     IST: await IST,
-    // ...(ausdcIssuer && { AUSDC: ausdcIssuer }),
+    ...(axlIssuer && { AXL: axlIssuer }),
     // ...(wavaxIssuer && { WAVAX: wavaxIssuer }),
   });
   trace('issuerKeywordRecord', issuerKeywordRecord);

--- a/contract/utils/gmp.js
+++ b/contract/utils/gmp.js
@@ -3,6 +3,7 @@
  */
 import { hexlify, arrayify, concat } from '@ethersproject/bytes';
 import { encode } from '@findeth/abi';
+import sha3 from "js-sha3";
 
 export const GMPMessageType = {
   MESSAGE_ONLY: 1,
@@ -10,6 +11,31 @@ export const GMPMessageType = {
   TOKEN_ONLY: 3,
 };
 harden(GMPMessageType);
+
+export const gmpAddresses = {
+  AXELAR_GMP:
+    "axelar1dv4u5k73pzqrxlzujxg3qp8kvc3pje7jtdvu72npnt5zhq05ejcsn5qme5",
+  AXELAR_GAS: "axelar1zl3rxpp70lmte2xr6c4lgske2fyuj3hupcsvcd",
+  OSMOSIS_RECEIVER: "osmo1yh3ra8eage5xtr9a3m5utg6mx0pmqreytudaqj",
+};
+
+const uint8ArrayToHex = (uint8Array) => {
+  return `0x${Array.from(uint8Array)
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("")}`;
+};
+
+export const encodeCallData = (functionSignature, paramTypes, params) => {
+  const functionHash = sha3.keccak256.digest(functionSignature);
+
+  return uint8ArrayToHex(
+    Uint8Array.from([
+      ...Uint8Array.from(functionHash.slice(0, 4)),
+      ...encode(paramTypes, params),
+    ])
+  );
+};
+
 
 /**
  * Builds a GMP payload for contract invocation

--- a/contract/yarn.lock
+++ b/contract/yarn.lock
@@ -265,6 +265,24 @@
     anylogger "^0.21.0"
     jessie.js "^0.3.4"
 
+"@agoric/internal@^0.4.0-u19.2":
+  version "0.4.0-u19.2"
+  resolved "https://registry.yarnpkg.com/@agoric/internal/-/internal-0.4.0-u19.2.tgz#e19a917dd2cdc44de127b5918d450c0eec99a3a2"
+  integrity sha512-1MKD9peGRmOKawu02TF8SV75XJIyCt1n/V5/VKWNyxck1RBVYRT7M7gOtF5AlYkMGCuRIVb7SY3iv7JWV0yXeg==
+  dependencies:
+    "@agoric/base-zone" "^0.1.1-u19.0"
+    "@endo/common" "^1.2.9"
+    "@endo/errors" "^1.2.9"
+    "@endo/far" "^1.1.10"
+    "@endo/init" "^1.1.8"
+    "@endo/marshal" "^1.6.3"
+    "@endo/pass-style" "^1.4.8"
+    "@endo/patterns" "^1.4.8"
+    "@endo/promise-kit" "^1.1.9"
+    "@endo/stream" "^1.2.9"
+    anylogger "^0.21.0"
+    jessie.js "^0.3.4"
+
 "@agoric/kmarshal@0.1.1-upgrade-19-dev-c605745.0+c605745":
   version "0.1.1-upgrade-19-dev-c605745.0"
   resolved "https://registry.yarnpkg.com/@agoric/kmarshal/-/kmarshal-0.1.1-upgrade-19-dev-c605745.0.tgz#8d9558a3fb139576cb4b6e5c8a7016f296c48f60"
@@ -456,6 +474,25 @@
     "@endo/patterns" "^1.4.8"
     "@endo/promise-kit" "^1.1.9"
 
+"@agoric/swingset-liveslots@^0.10.3-u19.2":
+  version "0.10.3-u19.2"
+  resolved "https://registry.yarnpkg.com/@agoric/swingset-liveslots/-/swingset-liveslots-0.10.3-u19.2.tgz#38e6560628cb426380b9f7c41cc3da12bb3e6d61"
+  integrity sha512-ZDFCg8t2sn0T6qAXzSjhbvrhE1drugJSjYjqr8tsjHGu4o5QKSZaxoEx770fouvbYUwRDCMOEp/lhxZkz7pqYw==
+  dependencies:
+    "@agoric/internal" "^0.4.0-u19.2"
+    "@agoric/store" "^0.9.3-u19.0"
+    "@endo/env-options" "^1.1.8"
+    "@endo/errors" "^1.2.9"
+    "@endo/eventual-send" "^1.3.0"
+    "@endo/exo" "^1.5.8"
+    "@endo/far" "^1.1.10"
+    "@endo/init" "^1.1.8"
+    "@endo/marshal" "^1.6.3"
+    "@endo/nat" "^5.0.14"
+    "@endo/pass-style" "^1.4.8"
+    "@endo/patterns" "^1.4.8"
+    "@endo/promise-kit" "^1.1.9"
+
 "@agoric/swingset-vat@0.32.3-upgrade-19-dev-c605745.0+c605745":
   version "0.32.3-upgrade-19-dev-c605745.0"
   resolved "https://registry.yarnpkg.com/@agoric/swingset-vat/-/swingset-vat-0.32.3-upgrade-19-dev-c605745.0.tgz#b318e9f62dcf260ec301e71646121e6690c8b110"
@@ -588,6 +625,18 @@
     "@agoric/base-zone" "^0.1.1-u19.0"
     "@agoric/store" "^0.9.3-u19.0"
     "@agoric/swingset-liveslots" "^0.10.3-u19.1"
+    "@endo/errors" "^1.2.9"
+    "@endo/exo" "^1.5.8"
+    "@endo/patterns" "^1.4.8"
+
+"@agoric/vat-data@^0.5.3-u19.2":
+  version "0.5.3-u19.2"
+  resolved "https://registry.yarnpkg.com/@agoric/vat-data/-/vat-data-0.5.3-u19.2.tgz#2f0a8599d4080197377c0d5968ca013c56a4ebd9"
+  integrity sha512-Yclbdco0Vy4qpGk5T/2yTbV7vAZ8/PPjKRd8GhMoPL9i1PW/jkqk50kTTxhVaBMzBeEF/luCBmgc25K1b2Glrw==
+  dependencies:
+    "@agoric/base-zone" "^0.1.1-u19.0"
+    "@agoric/store" "^0.9.3-u19.0"
+    "@agoric/swingset-liveslots" "^0.10.3-u19.2"
     "@endo/errors" "^1.2.9"
     "@endo/exo" "^1.5.8"
     "@endo/patterns" "^1.4.8"
@@ -2278,6 +2327,11 @@ jessie.js@^0.3.4:
   integrity sha512-JYJm6nXuFIO/X6OWLBatorgqmFVYbenqnFP0UDalO2OQ6sn58VeJ3cKtMQ0l0TM0JnCx4wKhyO4BQQ/ilxjd6g==
   dependencies:
     "@endo/far" "^1.0.0"
+
+js-sha3@^0.9.3:
+  version "0.9.3"
+  resolved "https://registry.yarnpkg.com/js-sha3/-/js-sha3-0.9.3.tgz#f0209432b23a66a0f6c7af592c26802291a75c2a"
+  integrity sha512-BcJPCQeLg6WjEx3FE591wVAevlli8lxsxm9/FzV4HXkV49TmBH38Yvrpce6fjbADGMKFrBMGTqrVz3qPIZ88Gg==
 
 js-tokens@^4.0.0:
   version "4.0.0"

--- a/ui/src/components/MakeAccount.tsx
+++ b/ui/src/components/MakeAccount.tsx
@@ -1,12 +1,15 @@
 import React from 'react';
 import { showError, showSuccess } from '../Utils';
-import { TOAST_DURATION } from '../config';
+import { TOAST_DURATION, BRAND_CONFIG, } from '../config';
 import { useAppStore } from '../state';
 import { toast } from 'react-toastify';
 
 export const MakeAccount = () => {
-  const { wallet, contractInstance, brands } = useAppStore.getState();
-
+  const { wallet, contractInstance, brands, currentOffers } = useAppStore.getState();
+  const BLD = {
+    brandKey: 'BLD',
+    decimals: 6,
+  };
   const makeOffer = async () => {
     let toastId: string | number | null = null;
 
@@ -15,17 +18,27 @@ export const MakeAccount = () => {
       if (!brands) throw new Error('Brands not initialized');
       if (!wallet) throw new Error('Wallet not connected');
 
-      const offerArgs = { chainName: 'osmosis' };
+
+
+      const requiredBrand = brands[BLD.brandKey];
+      const amountValue = BigInt(8000);
+
+      const give = {
+        [BLD.brandKey]: {
+          brand: requiredBrand,
+          value: amountValue,
+        },
+      };
 
       await new Promise<void>((resolve, reject) => {
         wallet.makeOffer(
           {
             source: 'contract',
             instance: contractInstance,
-            publicInvitationMaker: 'createAndMonitorAccount',
+            publicInvitationMaker: 'createAndMonitorLCA',
           },
+          { give },
           {},
-          offerArgs,
           (update: { status: string; data?: unknown }) => {
             switch (update.status) {
               case 'error':
@@ -55,12 +68,83 @@ export const MakeAccount = () => {
     }
   };
 
+  const makeOfferToLCA = async () => {
+    if (!latestInvitation) return;
+
+    const requiredBrand = brands?.[BLD.brandKey];
+    const amountValue = BigInt(1000000);
+
+    const give = {
+      [BLD.brandKey]: {
+        brand: requiredBrand,
+        value: amountValue,
+      },
+    };
+    const args =  {
+      id: Date.now(),
+      invitationSpec: {
+        source: 'continuing',
+        previousOffer: latestInvitation[0],
+        invitationMakerName: 'CallContractWithFunctionCalls',
+      },
+      offerArgs: {},
+      proposal: { give },
+    };
+    let toastId: string | number | null = null;
+
+    try {
+      if (!wallet) throw new Error('Wallet not connected');
+
+      await new Promise<void>((resolve, reject) => {
+        wallet.makeOffer(
+          args.invitationSpec,
+          args.proposal,
+          args.offerArgs,
+          (update: { status: string; data?: unknown }) => {
+            switch (update.status) {
+              case 'error':
+                reject(new Error(`Offer error: ${update.data}`));
+                break;
+              case 'accepted':
+                toast.success('Offer accepted!');
+                resolve();
+                break;
+              case 'refunded':
+                reject(new Error('Offer was rejected'));
+                break;
+            }
+          }
+        );
+      });
+
+      showSuccess({
+        content: 'Transaction Submitted Successfully',
+        duration: TOAST_DURATION.SUCCESS,
+      });
+    } catch (error) {
+      showError({ content: error.message, duration: TOAST_DURATION.ERROR });
+    } finally {
+      if (toastId) toast.dismiss(toastId);
+      useAppStore.setState({ loading: false });
+    }
+  }
+
+  const invitations = currentOffers?.offerToUsedInvitation.filter(
+    (invitation) => invitation[1].value[0].instance === contractInstance
+  );
+  const latestInvitation = invitations?.sort((a, b) =>
+    b[0].localeCompare(a[0])
+  )[0];
+
   return (
     <div className='dashboard-container'>
       <div className='dashboard'>
         <div className='transfer-form'>
           <button className='invoke-button' onClick={makeOffer}>
             Make Account
+          </button>
+          <button className='invoke-button' onClick={makeOfferToLCA} disabled={!latestInvitation}>
+            Use Account {latestInvitation ? `(${latestInvitation[0]})` : ''}
           </button>
         </div>
       </div>

--- a/ui/src/interfaces/interfaces.ts
+++ b/ui/src/interfaces/interfaces.ts
@@ -3,6 +3,21 @@ import { EVM_CHAINS } from '../config';
 
 type Wallet = Awaited<ReturnType<typeof makeAgoricWalletConnection>>;
 
+export interface CurrentOffer {
+  liveOffers: Array<unknown>;
+  offerToPublicSubscriberPaths: Array<unknown>;
+  offerToUsedInvitation: Array<[string, {
+    brand: unknown;
+    value: Array<{
+      description: string;
+      handle: unknown;
+      instance: unknown;
+      installation: unknown;
+    }>
+  }]>;
+  purses: Array<unknown>;
+};
+
 export interface OfferArgs {
   type: number;
   destinationEVMChain: (typeof EVM_CHAINS)[keyof typeof EVM_CHAINS];
@@ -26,6 +41,7 @@ export interface AppState {
   contractInvocationPayload?: number[];
   transactionUrl: string | null;
   tab: number;
+  currentOffers: CurrentOffer | null;
 }
 
 export interface BalanceCheckParams {

--- a/ui/src/state.ts
+++ b/ui/src/state.ts
@@ -12,4 +12,5 @@ export const useAppStore = create<AppState>((set) => ({
   type: 3,
   transactionUrl: null,
   tab: 1,
+  currentOffers: null,
 }));


### PR DESCRIPTION
This PR updates the dapp-evm to create a remote account.
The remote account has the functionality to call any contract on ethereum (acting as a generic proxy between agoric and ethereum)

The accompanying eth contact is [this](https://github.com/agoric-labs/agoric-to-axelar-local/blob/e024e9c99bcd700b4a01178de195e1e559f7d44e/packages/axelar-local-dev-cosmos/src/__tests__/contracts/Factory.sol) which implements the remote account and its factory contract as well